### PR TITLE
Simplify shop page: hide countdown and sections for pre-launch

### DIFF
--- a/shop/index.html
+++ b/shop/index.html
@@ -157,7 +157,7 @@
     
     <!-- Styles -->
     <link rel="stylesheet" href="../style.css?v=3">
-    <link rel="stylesheet" href="shop.css?v=3">
+    <link rel="stylesheet" href="shop.css?v=4">
 </head>
 <body>
     <header>

--- a/shop/shop.css
+++ b/shop/shop.css
@@ -1491,4 +1491,23 @@ main, footer {
         font-weight: 500 !important;
         line-height: 1.5 !important;
     }
+}
+
+/* TEMPORARY: Simplified shop version - Hide countdown and sections */
+.countdown-container {
+    display: none !important;
+}
+
+.healing-purpose-section {
+    display: none !important;
+}
+
+.real-impact-section {
+    display: none !important;
+}
+
+.shop-closed-title {
+    font-size: 2rem !important;
+    margin-top: 2rem !important;
+    margin-bottom: 2rem !important;
 } 


### PR DESCRIPTION
- Hide countdown timer container
- Hide 'Crafted with Heart' section
- Hide 'Each Drop Creates Real Impact' section
- Update CSS version to v4 for cache busting

This creates a clean, simplified shop page with just:
- Still Healing logo
- 'First Drop Opens Soon' title
- 'GET EARLY ACCESS' button

All functionality preserved, easily reversible by removing CSS rules.