### PR TITLE
Update shop drop date to December 1, 2025

### DIFF
--- a/shop/index.html
+++ b/shop/index.html
@@ -539,8 +539,8 @@
         const smsSignupForm = document.getElementById('smsSignupForm');
         const smsFormSuccess = document.getElementById('sms-form-success');
         
-        // Countdown target date (UTC): 2025-09-08T00:00:00Z
-        const dropDate = new Date('2025-09-08T00:00:00Z').getTime();
+        // Countdown target date (UTC): 2025-12-01T00:00:00Z
+        const dropDate = new Date('2025-12-01T00:00:00Z').getTime();
         
         // Testing override
         const isOverrideEnabled = localStorage.getItem('drop_waitlist_override_enabled') === 'true';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the pre-drop countdown target date to December 1, 2025 (00:00 UTC). The on-site countdown now reflects the new timeline, and the pre-drop overlay will remain visible until the timer reaches zero, after which it will auto-hide as before. No changes to layout, styling, performance, or other interactions beyond the schedule update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->